### PR TITLE
Add ponydocs to the list of awesome CMSes

### DIFF
--- a/data.toml
+++ b/data.toml
@@ -183,6 +183,13 @@ github_repo = "wikimedia/mediawiki"
 language = "php"
 
 [[cms]]
+name = "Ponydocs"
+description = "Ponydocs is Splunk's MediaWiki-powered documentation platform. Ponydocs is free and open source."
+url = "http://docs.splunk.com/Documentation/Ponydocs/1.0/Content/WhatisPonydocs"
+github_repo = "splunk/ponydocs"
+language = "php"
+
+[[cms]]
 name = "AsgardCms - A laravel CMS that's modular and multilingual"
 description = "A modular multilingual CMS built with Laravel 5."
 url = "https://asgardcms.com/"


### PR DESCRIPTION
- [x] verified that the CMS I'm adding is still maintained.
- [x] read [CONTRIBUTING.md](/CONTRIBUTING.md).
- [x] did not generate README.md.

Now pondering the proper plural of CMS. Ponydocs is a documentation-specific CMS that is, frankly, awesome for churning out documentation with different products, versions, child products, different manuals, and a generic "latest" for all your generic version needs. Supported and in heavy use by Splunk, it proves that a CMS can be a wiki but the content doesn't have to look like a wiki.