### PR TITLE
Add Contenta CMS to the list

### DIFF
--- a/contentacms#contenta_jsonapi.toml
+++ b/contentacms#contenta_jsonapi.toml
@@ -1,0 +1,5 @@
+name = "Contenta CMS"
+description = "Open Source Healess CMS powered by Drupal. Contenta CMS is for highly structured content. Contenta CMS uses leverages the data modelling tools from Drupal and offers a queriable API and a friendly admin interface."
+url = "http://contentacms.org/"
+github_repo = "contentacms/contenta_jsonapi"
+language = "php"


### PR DESCRIPTION
Contenta is a FOSS Drupal based decoupled CMS created as part of the API-First effort in the Drupal community.

More on http://contentacms.org

- [x] verified that the CMS I'm adding is still maintained.
- [x] read [CONTRIBUTING.md](/CONTRIBUTING.md).
- [x] did not generate README.md.
