### PR TITLE
Delete thegrid.toml

### DIFF
--- a/data/thegrid.toml
+++ b/data/thegrid.toml
@@ -1,3 +1,0 @@
-name = "The Grid"
-description = "AI websites that design themselves."
-url = "https://thegrid.io"


### PR DESCRIPTION
https://thegrid.io/ lists the project as "sunset"

(additional citation: [i worked there](https://github.com/the-grid/ed) three years ago)

- [x] verified that the CMS I'm ~adding~ removing is ~still~ not maintained.
- [x] read [CONTRIBUTING.md](https://github.com/postlight/awesome-cms/blob/master/CONTRIBUTING.md).
- [x] did not generate README.md.
