### PR TITLE
added Pelican static site generator in Python

### DIFF
--- a/data/pelican#pelican.toml
+++ b/data/pelican#pelican.toml
@@ -1,0 +1,5 @@
+name = "Pelican"
+description = "The Pelican static file content management system"
+url = "https://blog.getpelican.com/"
+github_repo = "getpelican/pelican"
+language = "python"


### PR DESCRIPTION
- [x] verified that the CMS I'm adding is still maintained.
- [x] read [CONTRIBUTING.md](https://github.com/postlight/awesome-cms/blob/master/CONTRIBUTING.md).
- [x] did not generate README.md.

fixes postlight/awesome-cms#129 "Pelican static site generator could be added"