### PR TITLE
Fix link to Sulu CMS

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -667,7 +667,6 @@
       "avatar_url": "https://avatars3.githubusercontent.com/u/1058963?v=4",
       "profile": "https://thingsthat.com",
       "contributions": [
-        "docs",
         "doc"
       ]
     },
@@ -686,7 +685,7 @@
       "avatar_url": "https://avatars1.githubusercontent.com/u/56605536?v=4",
       "profile": "https://frontaid.io/",
       "contributions": [
-        "docs"
+        "doc"
       ]
     },
     {
@@ -695,7 +694,7 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/22985657?v=4",
       "profile": "http://blog.albiona.dev",
       "contributions": [
-        "docs"
+        "doc"
       ]
     },
     {
@@ -704,7 +703,7 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/5363448?v=4",
       "profile": "https://paescuj.ch",
       "contributions": [
-        "docs"
+        "doc"
       ]
     },
     {
@@ -713,7 +712,7 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/32982428?v=4",
       "profile": "https://zeprof2code.github.io",
       "contributions": [
-        "docs"
+        "doc"
       ]
     }
   ],

--- a/data/sulu#sulu.toml
+++ b/data/sulu#sulu.toml
@@ -1,5 +1,5 @@
 name = "Sulu"
 description = "Sulu is a content management platform based on Symfony made for businesses. It’s a flexible CMS to create and manage enterprise multi-sites and a reliable development environment for high-performance apps"
 url = "http://sulu.io/en"
-github_repo = "sulu/sulu-standard"
+github_repo = "sulu/sulu"
 language = "php"


### PR DESCRIPTION
The correct repository to track Sulu commits is [`sulu/sulu`](https://github.com/sulu/sulu) repository.

- [x] verified that the CMS I'm adding is still maintained.
- [x] read [CONTRIBUTING.md](https://github.com/postlight/awesome-cms/blob/master/CONTRIBUTING.md).
- [x] did not generate README.md.
