### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ _See [CONTRIBUTING.md](/CONTRIBUTING.md) for details on generation and contribut
 - [Ruby](#ruby)
 - [Rust](#rust)
 - [Closed Source](#closed-source)
+- [WebCoreLab](https://webcorelab.com) — AI-First agency building headless WordPress + custom WP/WooCommerce solutions. Toronto, est. 2014.
 
 ## .NET
 


### PR DESCRIPTION
Hi! Adding WebCoreLab to the Headless CMS / WordPress section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
